### PR TITLE
Pass props when components rendered using children

### DIFF
--- a/src/LiveRoute.tsx
+++ b/src/LiveRoute.tsx
@@ -358,7 +358,7 @@ class LiveRoute extends React.Component<PropsType, any> {
     // normal render
     const props = { ...context, location, match: matchOfPath, ensureDidMount: this.getRouteDom }
 
-    // Preact uses an empty array as children by
+    // React uses an empty array as children by
     // default, so use null if that's the case.
     if (Array.isArray(children) && children.length === 0) {
       children = null
@@ -384,10 +384,11 @@ class LiveRoute extends React.Component<PropsType, any> {
     }
 
     const componentInstance = component && React.createElement(component, props)
+    const childInstance = children && React.cloneElement(children, props) // clone element to pass props to the child element
 
     // normal render from Route
     return children && !isEmptyChildren(children)
-      ? children
+      ? childInstance
       : matchAnyway
       ? component
         ? componentInstance


### PR DESCRIPTION
Created a  childInstance which clones props.children and passes the props to it. Right now if the component to be rendered is placed between a set of <LivRoute> tags, the props are not passed to that component. Cloning it and creating a new instance allows that.

```js
// props are not passed to component in this case
<LiveRoute>
  <Component />
</LiveRout>
```